### PR TITLE
Comment out "persist.sys.first.frame.accelerates"

### DIFF
--- a/Module/system.prop
+++ b/Module/system.prop
@@ -348,8 +348,10 @@ persist.sys.turbosched.thermal_break.enable=false
 # Mi Perf
 persist.miui.miperf.enable=false
 
-# Aceelerates app first frame on launch
-persist.sys.first.frame.accelerates=true
+# Accelerates app first frame on launch
+# some phones do not work with this prop
+# if you'd like to test your luck, be my guest
+# persist.sys.first.frame.accelerates=true
 
 # Performance Hinting
 # persist.sys.enable_perf_hint=false


### PR DESCRIPTION
This fixes the black screen on boot some phones might have when they use the unsafe version.

I am not sure why some phones break with this. I have a feeling it's an MTK issue, since my phone is an MTK and has this issue. (Not entirely sure!)

I thought it would be a good idea to comment it out for the sake of universality, so most phones can work with as many props added as possible.